### PR TITLE
Langstore sync issue + promote stuck with with a project in processed state in the queue

### DIFF
--- a/actions/graybox/copy-sched.js
+++ b/actions/graybox/copy-sched.js
@@ -36,84 +36,94 @@ async function main(params) {
         projectQueue = projectQueue.sort((a, b) => a.createdTime - b.createdTime);
 
         // Find the First Project where status is 'processed'
-        const projectEntry = projectQueue.find((project) => project.status === 'processed');
-        if (projectEntry && projectEntry.projectPath) {
-            const project = projectEntry.projectPath;
-            const projectStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/status.json`);
-            logger.info(`In Copy-sched Project Status for project: ${project} is: ${JSON.stringify(projectStatusJson)}`);
+        const projectEntries = projectQueue.filter((project) => project.status === 'processed');
+        if (projectEntries && projectEntries.length > 0) {
+            const processedProjects = [];
+            const triggeredActions = [];
 
-            // Read the Batch Status in the current project's "batch_status.json" file
-            const batchStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/batch_status.json`);
-            logger.info(`In Copy Sched, Batch Status Json for project: ${project} is: ${JSON.stringify(batchStatusJson)}`);
+            // Process all projects with status 'processed'
+            const projectResults = await Promise.allSettled(
+                projectEntries.map(async (projectEntry) => {
+                    const project = projectEntry.projectPath;
+                    try {
+                        const projectStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/status.json`);
+                        logger.info(`In Copy-sched Project Status for project: ${project} is: ${JSON.stringify(projectStatusJson)}`);
 
-            const copyBatchesJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/copy_batches.json`);
-            logger.info(`In Copy-sched Copy Batches Json for project: ${project} is: ${JSON.stringify(copyBatchesJson)}`);
+                        // Read the Batch Status in the current project's "batch_status.json" file
+                        const batchStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/batch_status.json`);
+                        logger.info(`In Copy Sched, Batch Status Json for project: ${project} is: ${JSON.stringify(batchStatusJson)}`);
 
-            // Find if any batch is in 'copy_in_progress' status, if yes then don't trigger another copy action for another "processed" batch
-            const copyOrPromoteInProgressBatch = Object.entries(batchStatusJson)
-                .find(([_, copyBatchJson]) => (copyBatchJson.status === 'copy_in_progress' || copyBatchJson.status === 'promote_in_progress'));
+                        const copyBatchesJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/copy_batches.json`);
+                        logger.info(`In Copy-sched Copy Batches Json for project: ${project} is: ${JSON.stringify(copyBatchesJson)}`);
 
-            if (copyOrPromoteInProgressBatch && Array.isArray(copyOrPromoteInProgressBatch) && copyOrPromoteInProgressBatch.length > 0) {
-                responsePayload = `Promote or Copy Action already in progress for project: ${project} for Batch: ${copyOrPromoteInProgressBatch[0]}, not triggering another action until it completes`;
-                return {
-                    code: 200,
-                    payload: responsePayload
-                };
-            }
+                        // Find if any batch is in 'copy_in_progress' status, if yes then don't trigger another copy action for another "processed" batch
+                        const copyOrPromoteInProgressBatch = Object.entries(batchStatusJson)
+                            .find(([, copyBatchJson]) => (copyBatchJson.status === 'copy_in_progress' || copyBatchJson.status === 'promote_in_progress'));
 
-            // Find the First Batch where status is 'processed', to promote one batch at a time
-            const processedBatchName = Object.keys(copyBatchesJson)
-                .find((batchName) => copyBatchesJson[batchName].status === 'processed');
-            // If no batch is found with status 'processed then nothing to promote', return
-            if (!processedBatchName) {
-                responsePayload = 'No Copy Batches found with status "processed"';
-                return {
-                    code: 200,
-                    payload: responsePayload
-                };
-            }
+                        if (copyOrPromoteInProgressBatch && Array.isArray(copyOrPromoteInProgressBatch) && copyOrPromoteInProgressBatch.length > 0) {
+                            logger.info(`Promote or Copy Action already in progress for project: ${project} for Batch: ${copyOrPromoteInProgressBatch[0]}, skipping to next project`);
+                            return { project, status: 'skipped', reason: 'action_in_progress' };
+                        }
 
-            if (copyBatchesJson[processedBatchName].status === 'processed') {
-                // copy all params from json into the params object
-                const inputParams = projectStatusJson?.params;
-                Object.keys(inputParams).forEach((key) => {
-                    params[key] = inputParams[key];
-                });
-                // Set the Project & Batch Name in params for the Copy Content Worker Action to read and process
-                params.project = project;
-                params.batchName = processedBatchName;
+                        // Find the First Batch where status is 'processed', to promote one batch at a time
+                        const processedBatchName = Object.keys(copyBatchesJson)
+                            .find((batchName) => copyBatchesJson[batchName].status === 'processed');
+                        // If no batch is found with status 'processed then nothing to promote', skip this project
+                        if (!processedBatchName) {
+                            logger.info(`No Copy Batches found with status "processed" for project: ${project}`);
+                            return { project, status: 'skipped', reason: 'no_processed_batches' };
+                        }
 
-                logger.info(`In Copy-sched, Invoking Copy Content Worker for Batch: ${processedBatchName} of Project: ${project}`);
-                try {
-                    return ow.actions.invoke({
-                        name: 'graybox/copy-worker',
-                        blocking: false,
-                        result: false,
-                        params
-                    }).then(async (result) => {
-                        logger.info(result);
-                        return {
-                            code: 200,
-                            payload: responsePayload
-                        };
-                    }).catch(async (err) => {
-                        responsePayload = 'Failed to invoke graybox copy action';
-                        logger.error(`${responsePayload}: ${err}`);
-                        return {
-                            code: 500,
-                            payload: responsePayload
-                        };
-                    });
-                } catch (err) {
-                    responsePayload = 'Unknown error occurred while invoking Copy Content Worker Action';
-                    logger.error(`${responsePayload}: ${err}`);
-                    responsePayload = err;
+                        if (copyBatchesJson[processedBatchName].status === 'processed') {
+                            // copy all params from json into the params object
+                            const inputParams = projectStatusJson?.params;
+                            const projectParams = { ...params };
+                            Object.keys(inputParams).forEach((key) => {
+                                projectParams[key] = inputParams[key];
+                            });
+                            // Set the Project & Batch Name in params for the Copy Content Worker Action to read and process
+                            projectParams.project = project;
+                            projectParams.batchName = processedBatchName;
+
+                            logger.info(`In Copy-sched, Invoking Copy Content Worker for Batch: ${processedBatchName} of Project: ${project}`);
+                            try {
+                                await ow.actions.invoke({
+                                    name: 'graybox/copy-worker',
+                                    blocking: false,
+                                    result: false,
+                                    params: projectParams
+                                });
+                                return { project, batchName: processedBatchName, status: 'triggered' };
+                            } catch (err) {
+                                logger.error(`Failed to invoke Copy Content Worker for project ${project}, batch ${processedBatchName}: ${err}`);
+                                return { project, status: 'failed', error: err.message };
+                            }
+                        }
+                        return { project, status: 'skipped', reason: 'batch_not_processed' };
+                    } catch (err) {
+                        logger.error(`Error processing project ${project}: ${err}`);
+                        return { project, status: 'error', error: err.message };
+                    }
+                })
+            );
+
+            // Process results and build response
+            projectResults.forEach((result) => {
+                if (result.status === 'fulfilled' && result.value.status === 'triggered') {
+                    processedProjects.push(result.value.project);
+                    triggeredActions.push(`${result.value.project}/${result.value.batchName}`);
                 }
+            });
+
+            if (processedProjects.length > 0) {
+                responsePayload = `Triggered Copy Content Worker Actions for ${processedProjects.length} projects: ${triggeredActions.join(', ')}`;
+            } else {
+                responsePayload = 'No projects were processed - all projects either have actions in progress or no processed batches';
             }
-            responsePayload = 'Triggered multiple Copy Content Worker Actions';
+
             return {
                 code: 200,
-                payload: responsePayload,
+                payload: responsePayload
             };
         }
     } catch (err) {

--- a/actions/graybox/initiate-promote-worker.js
+++ b/actions/graybox/initiate-promote-worker.js
@@ -47,7 +47,19 @@ async function main(params) {
     const sharepoint = new Sharepoint(appConfig);
     const project = `${gbRootFolder}/${experienceName}`;
 
-    await filesWrapper.writeFile(`graybox_promote${project}/status.json`, {});
+    const projectStatusInitialJson = {
+        status: 'initiated',
+        statuses: [
+            {
+                stepName: 'initiated',
+                step: 'Initiated',
+                timestamp: toUTCStr(new Date()),
+                files: []
+            }
+        ]
+    };
+
+    await filesWrapper.writeFile(`graybox_promote${project}/status.json`, projectStatusInitialJson);
 
     try {
         // Update Promote Status

--- a/actions/graybox/initiate-promote-worker.js
+++ b/actions/graybox/initiate-promote-worker.js
@@ -61,7 +61,7 @@ async function main(params) {
 
     // Get all files in the graybox folder for the specific experience name
     // NOTE: This does not capture content inside the locale/expName folders yet
-    let { gbFiles, gbFilesMetadata } = await findAllFiles(experienceName, appConfig, sharepoint, draftsOnly);
+    const { gbFiles, gbFilesMetadata } = await findAllFiles(experienceName, appConfig, sharepoint, draftsOnly);
     const grayboxFilesToBePromoted = [['Graybox files to be promoted', toUTCStr(new Date()), '', JSON.stringify(gbFiles)]];
     await sharepoint.updateExcelTable(projectExcelPath, 'PROMOTE_STATUS', grayboxFilesToBePromoted);
 
@@ -69,8 +69,8 @@ async function main(params) {
     await filesWrapper.writeFile(`graybox_promote${project}/master_list.json`, gbFiles);
     const gbFilesMetadataObject = { sourceMetadata: gbFilesMetadata };
     await filesWrapper.writeFile(`graybox_promote${project}/master_list_metadata.json`, gbFilesMetadataObject);
-    gbFiles = []; // todo: remove this line
-    gbFilesMetadata = []; // todo: remove this line
+    // gbFiles = []; // todo: remove this line
+    // gbFilesMetadata = []; // todo: remove this line
     // Create Batch Status JSON
     const batchStatusJson = {};
 
@@ -255,6 +255,7 @@ async function findAllGrayboxFiles({
                         // it is a folder
                         gbFolders.push(itemPath);
                     } else if (pathsToSelectRegExp.test(itemPath)) {
+                        logger.info(`Found file from experience folder ${experienceName} : ${itemPath}`);
                         const simplifiedMetadata = {
                             createdDateTime: item.createdDateTime,
                             lastModifiedDateTime: item.lastModifiedDateTime,

--- a/actions/graybox/promote-sched.js
+++ b/actions/graybox/promote-sched.js
@@ -36,80 +36,90 @@ async function main(params) {
         projectQueue = projectQueue.sort((a, b) => a.createdTime - b.createdTime);
 
         // Find the First Project where status is 'processed'
-        const projectEntry = projectQueue.find((project) => project.status === 'processed');
+        const projectEntries = projectQueue.filter((project) => project.status === 'processed');
+        logger.info(`In Promote Sched, projectEntries: ${JSON.stringify(projectEntries)}`);
 
-        if (projectEntry && projectEntry.projectPath) {
-            const project = projectEntry.projectPath;
-            const projectStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/status.json`);
-
-            // Read the Batch Status in the current project's "batch_status.json" file
-            const batchStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/batch_status.json`);
-            logger.info(`In Promote Sched, batchStatusJson for project: ${project} is: ${JSON.stringify(batchStatusJson)}`);
-
-            // Find if any batch is in 'copy_in_progress' status, if yes then don't trigger another copy action for another "processed" batch
-            const copyOrPromoteInProgressBatch = Object.entries(batchStatusJson)
-                .find(([batchName, copyBatchJson]) => (copyBatchJson.status === 'copy_in_progress' || copyBatchJson.status === 'promote_in_progress'));
-
-            if (copyOrPromoteInProgressBatch && Array.isArray(copyOrPromoteInProgressBatch) && copyOrPromoteInProgressBatch.length > 0) {
-                responsePayload = `Promote or Copy Action already in progress for project: ${project} for Batch: ${copyOrPromoteInProgressBatch[0]}, not triggering another action until it completes`;
-                return {
-                    code: 200,
-                    payload: responsePayload
-                };
-            }
-
-            const promoteBatchesJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/promote_batches.json`);
-
-            // Find the First Batch where status is 'processed', to promote one batch at a time
-            const processedBatchName = Object.keys(promoteBatchesJson)
-                .find((batchName) => promoteBatchesJson[batchName].status === 'processed');
-            // If no batch is found with status 'processed then nothing to promote', return
-            if (!processedBatchName) {
-                responsePayload = 'No Promote Batches found with status "processed"';
-                return {
-                    code: 200,
-                    payload: responsePayload
-                };
-            }
-
-            if (promoteBatchesJson[processedBatchName].status === 'processed') {
-                // copy all params from json into the params object
-                const inputParams = projectStatusJson?.params;
-                Object.keys(inputParams).forEach((key) => {
-                    params[key] = inputParams[key];
-                });
-                // Set the Project & Batch Name in params for the Promote Content Worker Action to read and process
-                params.project = project;
-                params.batchName = processedBatchName;
-
-                logger.info(`In Promote Sched, Invoking Promote Content Worker for Batch: ${processedBatchName} of Project: ${project}`);
+        if (projectEntries && projectEntries.length > 0) {
+            // Process each project entry instead of just the first one
+            const processProject = async (projectEntry) => {
+                const project = projectEntry.projectPath;
                 try {
-                    return ow.actions.invoke({
-                        name: 'graybox/promote-worker',
-                        blocking: false,
-                        result: false,
-                        params
-                    }).then(async (result) => {
-                        logger.info(result);
-                        return {
-                            code: 200,
-                            payload: responsePayload
-                        };
-                    }).catch(async (err) => {
-                        responsePayload = 'Failed to invoke graybox promote action';
-                        logger.error(`${responsePayload}: ${err}`);
-                        return {
-                            code: 500,
-                            payload: responsePayload
-                        };
-                    });
+                    const projectStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/status.json`);
+
+                    // Read the Batch Status in the current project's "batch_status.json" file
+                    const batchStatusJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/batch_status.json`);
+                    logger.info(`In Promote Sched, batchStatusJson for project: ${project} is: ${JSON.stringify(batchStatusJson)}`);
+
+                    // Find if any batch is in 'copy_in_progress' status, if yes then don't trigger another copy action for another "processed" batch
+                    const copyOrPromoteInProgressBatch = Object.entries(batchStatusJson)
+                        .find(([, copyBatchJson]) => (copyBatchJson.status === 'copy_in_progress' || copyBatchJson.status === 'promote_in_progress'));
+
+                    if (copyOrPromoteInProgressBatch && Array.isArray(copyOrPromoteInProgressBatch) && copyOrPromoteInProgressBatch.length > 0) {
+                        logger.info(`Promote or Copy Action already in progress for project: ${project} for Batch: ${copyOrPromoteInProgressBatch[0]}, skipping this project`);
+                        return { skipped: true, project };
+                    }
+
+                    const promoteBatchesJson = await filesWrapper.readFileIntoObject(`graybox_promote${project}/promote_batches.json`);
+
+                    // Find the First Batch where status is 'processed', to promote one batch at a time
+                    const processedBatchName = Object.keys(promoteBatchesJson)
+                        .find((batchName) => promoteBatchesJson[batchName].status === 'processed');
+                    // If no batch is found with status 'processed then nothing to promote', skip this project
+                    if (!processedBatchName) {
+                        logger.info(`No Promote Batches found with status "processed" for project: ${project}`);
+                        return { skipped: true, project };
+                    }
+
+                    if (promoteBatchesJson[processedBatchName].status === 'processed') {
+                        // copy all params from json into the params object
+                        const inputParams = projectStatusJson?.params;
+                        const projectParams = { ...params };
+                        Object.keys(inputParams).forEach((key) => {
+                            projectParams[key] = inputParams[key];
+                        });
+                        // Set the Project & Batch Name in params for the Promote Content Worker Action to read and process
+                        projectParams.project = project;
+                        projectParams.batchName = processedBatchName;
+
+                        logger.info(`In Promote Sched, Invoking Promote Content Worker for Batch: ${processedBatchName} of Project: ${project}`);
+                        try {
+                            await ow.actions.invoke({
+                                name: 'graybox/promote-worker',
+                                blocking: false,
+                                result: false,
+                                params: projectParams
+                            }).then(async (result) => {
+                                logger.info(result);
+                            }).catch(async (err) => {
+                                const errorMsg = 'Failed to invoke graybox promote action';
+                                logger.error(`${errorMsg}: ${err}`);
+                            });
+                        } catch (err) {
+                            const errorMsg = 'Unknown error occurred while invoking Promote Content Worker Action';
+                            logger.error(`${errorMsg}: ${err}`);
+                        }
+                    }
+                    logger.info(`Triggered Promote Content Worker Action for project: ${project}`);
+                    return { processed: true, project };
                 } catch (err) {
-                    responsePayload = 'Unknown error occurred while invoking Promote Content Worker Action';
-                    logger.error(`${responsePayload}: ${err}`);
-                    responsePayload = err;
+                    logger.error(`Error processing project ${project}: ${err}`);
+                    return { error: true, project };
                 }
-            }
-            responsePayload = 'Triggered Promote Content Worker Action';
+            };
+
+            // Process all projects sequentially
+            const results = await projectEntries.reduce(async (previousPromise, projectEntry) => {
+                const accumulator = await previousPromise;
+                const result = await processProject(projectEntry);
+                accumulator.push(result);
+                return accumulator;
+            }, Promise.resolve([]));
+
+            const processedCount = results.filter((r) => r.processed).length;
+            const skippedCount = results.filter((r) => r.skipped).length;
+            const errorCount = results.filter((r) => r.error).length;
+
+            responsePayload = `Processed ${processedCount} projects, skipped ${skippedCount} projects, ${errorCount} errors`;
             return {
                 code: 200,
                 payload: responsePayload,

--- a/actions/graybox/promote-worker.js
+++ b/actions/graybox/promote-worker.js
@@ -102,7 +102,7 @@ async function main(params) {
             } else if (saveStatus?.errorMsg?.includes('File is locked')) {
                 failedPromotes.push(`${promoteFilePath} (locked file)`);
             } else {
-                failedPromotes.push(promoteFilePath);
+                failedPromotes.push(`${promoteFilePath} (failed with reason: ${saveStatus?.errorMsg})`);
             }
         }
     }


### PR DESCRIPTION
- If one project is stuck in the `processed` state in the project queue, the next processed projects were not being processed. That is fixed by iterating over all projects in the `processed` state rather than finding the first one.
- Regarding langstore sync - Updated the regex and the finding of files for a given experience. Tested the following scenario


```
For drafts only = false
/<experienceName>/<folder>/a.docx
/<experienceName>/<folder>/b.xlsx
/<experienceName>/<folder>/<fragments>b.docx

/<langstore>/en/<experienceName>/<folder>/a.docx
/<langstore>/de/<experienceName>/<folder>/a.docx

/<locale>/<experienceName>/b.docx
/<locale>/<experienceName>/<folder>/a.docx



For drafts only = true
/<experienceName>/drafts/<folder>/a.docx
/<experienceName>/drafts/<folder>/b.xlsx
/<experienceName>/drafts/<folder>/<fragments>b.docx

/<langstore>/en/<experienceName>/drafts/<folder>/a.docx
/<langstore>/de/<experienceName>/drafts/<folder>/a.docx

/<locale>/<experienceName>/drafts/b.docx
/<locale>/<experienceName>/drafts/<folder>/a.docx
```